### PR TITLE
Build and lint workflow

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -1,0 +1,93 @@
+name: Docker image CI
+
+on:
+  # When a PR is open, then push and pull_request will be triggered. While they
+  # seem similar, push is for the pushed commit and pull_request is for the
+  # merge of the PR on the target branch.
+  push:
+  pull_request:
+    branches:
+      - "main"
+  schedule:
+    - cron: "*/30 * * * *"
+
+env:
+  image_name: ghcr.io/chprat/linters
+  testing_tag: testing
+  testing_image_name: testing-image
+  image_export_path: /tmp/testing-image.tar
+
+jobs:
+  build-image:
+    runs-on: ubuntu-latest
+    # The (restricted) default permissions are only read access for contents,
+    # but we need to write packages also. As all not explicitly stated
+    # permissions are none, we need to add contents: read, too.
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v3
+
+      - name: Set up Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.image_name }}
+          tags: |
+            type=schedule,pattern={{ date 'YYYYMMDD' }}
+            type=ref,event=branch
+            type=ref,event=pr
+            type=raw,value=latest,enable={{ is_default_branch }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and export new image
+        uses: docker/build-push-action@v5
+        with:
+          tags: ${{ env.image_name }}:${{ env.testing_tag }}
+          outputs: type=docker,dest=${{ env.image_export_path }}
+
+      - name: Push new image
+        uses: docker/build-push-action@v5
+        with:
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Upload image artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ env.testing_image_name }}
+          path: ${{ env.image_export_path }}
+
+  run-linters:
+    runs-on: ubuntu-latest
+    needs: build-image
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v3
+
+      - name: Download image artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: ${{ env.testing_image_name }}
+          path: /tmp
+
+      - name: Import image
+        run: docker load --input ${{ env.image_export_path }}
+
+      - name: Run linters from new image
+        run: docker run --rm -v $(pwd):/code:ro ${{ env.image_name }}:${{ env.testing_tag }}

--- a/README.md
+++ b/README.md
@@ -12,3 +12,21 @@ These linters are currently included:
 - [hadolint](https://github.com/hadolint/hadolint) for Dockerfiles
 - [markdownlint](https://github.com/markdownlint/markdownlint) for Markdown files
 - [shellcheck](https://github.com/koalaman/shellcheck) for shell scripts
+
+Usage
+-----
+
+To use the Docker image, you can pull it from the repositories integrated
+package repository. To use it you need to:
+
+- create a file *lint.sh*, which calls the linters in the container
+- mount your source code folder to the folder */code* in the container
+- create configuration files for the linters, if required
+
+Docker image tags
+-----------------
+
+Through GitHub Actions several tagged versions of the Docker image are
+available. The image name is `ghcr.io/chprat/linters`, the available tags are:
+
+- `:<branch>`: built from a branch


### PR DESCRIPTION
Add a first workflow, that builds and pushes the Docker image and runs the linters from the image on our code.