### PR TITLE
Add package cleanup workflow

### DIFF
--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -15,6 +15,9 @@ jobs:
       contents: read
       packages: write
     steps:
+      - name: Checkout sources
+        uses: actions/checkout@v3
+
       - name: Delete all untagged images
         uses: actions/delete-package-versions@v4
         with:
@@ -22,3 +25,32 @@ jobs:
           package-type: container
           min-versions-to-keep: 0
           delete-only-untagged-versions: true
+      - name: Delete images from deleted branches
+        run: |
+          # Get all image tags, API access described at
+          # https://docs.github.com/en/rest/packages/packages?apiVersion=2022-11-28#list-packages-for-a-user
+          api_result="$(curl -sL -H "Accept: application/vnd.github+json" \
+                        -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+                        -H "X-GitHub-Api-Version: 2022-11-28" \
+                        https://api.github.com/users/chprat/packages/container/linters/versions)"
+          # Remove main, latest and all date tags from the list
+          filtered_image_tags="$(echo $api_result | jq -r ".[].metadata.container.tags[]" \
+                                  | grep -v "^[0-9]*$\|latest\|main")"
+          # iterate over the filtered list of image tags
+          while IFS= read -r line ; do
+            # check if a branch for the tag exists
+            echo "$line branch still exists"
+            if ! git ls-remote --exit-code --heads origin "$line" &> /dev/null; then
+              # get the ID of the tagged image
+              image_id="$(echo $api_result | jq -r ".[] | select(.metadata.container.tags[] == \"$line\") | .id")"
+              echo "$line branch doesn't exist anymore, delete the image"
+              # delete the image, API access described at
+              # https://docs.github.com/en/rest/packages/packages?apiVersion=2022-11-28#delete-package-version-for-a-user
+              curl -sL -X DELETE \
+                -H "Accept: application/vnd.github+json" \
+                -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+                -H "X-GitHub-Api-Version: 2022-11-28" \
+                "https://api.github.com/users/chprat/packages/container/linters/versions/$image_id"
+            fi
+          done <<< "$filtered_image_tags"
+

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -1,0 +1,24 @@
+name: Docker package cleanup
+
+on:
+  push:
+  schedule:
+    - cron: "0 4 * * *"
+
+jobs:
+  cleanup-packages:
+    runs-on: ubuntu-latest
+    # The (restricted) default permissions are only read access for contents,
+    # but we need to write packages also. As all not explicitly stated
+    # permissions are none, we need to add contents: read, too.
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Delete all untagged images
+        uses: actions/delete-package-versions@v4
+        with:
+          package-name: linters
+          package-type: container
+          min-versions-to-keep: 0
+          delete-only-untagged-versions: true

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -9,7 +9,7 @@ on:
     branches:
       - "main"
   schedule:
-    - cron: "*/30 * * * *"
+    - cron: "0 5 * * *"
 
 env:
   image_name: ghcr.io/chprat/linters

--- a/README.md
+++ b/README.md
@@ -29,4 +29,6 @@ Docker image tags
 Through GitHub Actions several tagged versions of the Docker image are
 available. The image name is `ghcr.io/chprat/linters`, the available tags are:
 
-- `:<branch>`: built from a branch
+- `:<branch>`: build from a branch
+- :`<date>`: scheduled build at a given date from the default branch
+- `:latest`: most recent build from the default branch


### PR DESCRIPTION
Add a GitHub Action workflow to delete Docker images from our package registry. Currently all untagged images and tagged images from deleted branches will be removed.