### PR TITLE
Cleanup old scheduled images

### DIFF
--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -1,7 +1,6 @@
 name: Docker package cleanup
 
 on:
-  push:
   schedule:
     - cron: "0 4 * * *"
 

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -25,6 +25,13 @@ jobs:
           package-type: container
           min-versions-to-keep: 0
           delete-only-untagged-versions: true
+      - name: Delete old scheduled images
+        uses: actions/delete-package-versions@v4
+        with:
+          package-name: linters
+          package-type: container
+          min-versions-to-keep: 4
+          ignore-versions: '^(?!\d+$).*'
       - name: Delete images from deleted branches
         run: |
           # Get all image tags, API access described at

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -37,6 +37,8 @@ jobs:
           filtered_image_tags="$(echo "$api_result" | jq -r ".[].metadata.container.tags[]" \
                                   | grep -v "^[0-9]*$\|latest\|main")"
           # iterate over the filtered list of image tags
+          number_of_tags="$(echo "$filtered_image_tags" | wc -l)"
+          echo "$number_of_tags possible tags to delete"
           while IFS= read -r line ; do
             # check if a branch for the tag exists
             echo "$line branch still exists"


### PR DESCRIPTION
Extend the cleanup job to delete old images and only run it scheduled, not on push.