### PR TITLE
Fix failing cleanup

### DIFF
--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -41,7 +41,7 @@ jobs:
                         https://api.github.com/users/chprat/packages/container/linters/versions)"
           # Remove main, latest and all date tags from the list
           filtered_image_tags="$(echo "$api_result" | jq -r ".[].metadata.container.tags[]" \
-                                  | grep -v "^[0-9]*$\|latest\|main")"
+                                  | grep -v "^[0-9]*$\|latest\|main" || true)"
           # iterate over the filtered list of image tags
           number_of_tags="$(echo "$filtered_image_tags" | wc -l)"
           echo "$number_of_tags possible tags to delete"

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -42,12 +42,19 @@ jobs:
           # Remove main, latest and all date tags from the list
           filtered_image_tags="$(echo "$api_result" | jq -r ".[].metadata.container.tags[]" \
                                   | grep -v "^[0-9]*$\|latest\|main" || true)"
-          # iterate over the filtered list of image tags
-          number_of_tags="$(echo "$filtered_image_tags" | wc -l)"
+          # Check if we need to run
+          if [ -z "$filtered_image_tags" ]; then
+              number_of_tags=0
+          else
+              number_of_tags="$(echo "$filtered_image_tags" | wc -l)"
+          fi
           echo "$number_of_tags possible tags to delete"
+          if [[ $number_of_tags -eq 0 ]]; then
+              exit
+          fi
+          # iterate over the filtered list of image tags
           while IFS= read -r line ; do
             # check if a branch for the tag exists
-            echo "$line branch still exists"
             if ! git ls-remote --exit-code --heads origin "$line" &> /dev/null; then
               # get the ID of the tagged image
               image_id="$(echo "$api_result" | jq -r ".[] | select(.metadata.container.tags[] == \"$line\") | .id")"
@@ -59,6 +66,8 @@ jobs:
                 -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
                 -H "X-GitHub-Api-Version: 2022-11-28" \
                 "https://api.github.com/users/chprat/packages/container/linters/versions/$image_id"
+            else
+              echo "$line branch still exists"
             fi
           done <<< "$filtered_image_tags"
 


### PR DESCRIPTION
Grep has an exit code of 1, when nothing was selected. Therefore the script to cleanup images of deleted branches failed, when no such image was available. Fix that by adding a "|| true" to the command. Also fix the script output and don't run the loop, when it is not necessary.